### PR TITLE
Change clojure dependency scope to provided

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,7 +2,7 @@
 (def version "0.2.0")
 
 (set-env! :resource-paths #{"resources" "src"}
-          :dependencies   '[[org.clojure/clojure "RELEASE"]
+          :dependencies   '[[org.clojure/clojure "RELEASE" :scope "provided"]
                             [boot/core "RELEASE" :scope "provided"]
                             [clj-http "RELEASE" :scope "test"]])
 


### PR DESCRIPTION
Thanks for tools-deps-alpha, its a great tool for tidying up boot projects and compatibility with the `clojure` repl!

Please use `provided` scope for Clojure dependency so dependent projects can use a different version of Clojure without `:exclusions` or conflicts.
