### PR TITLE
Update tools.deps.alpha version for authenticated repo support

### DIFF
--- a/src/boot_tools_deps/core.clj
+++ b/src/boot_tools_deps/core.clj
@@ -12,7 +12,7 @@
 
 (def ^:private tools-deps-version
   "The version of tools.deps(.alpha) that we are known to work with."
-  "0.5.417")
+  "0.5.452")
 
 (defn- load-default-deps
   "Read our default-deps.edn file and substitute some values.


### PR DESCRIPTION
Support for authenticated Maven repos was added to tools.deps in 0.5.435, so with this change boot-tools-deps will pick up credentials in a user's `~/.m2/settings.xml` to authenticate with. There's a few other fixes also picked up by updating the version, see [changelog](https://github.com/clojure/tools.deps.alpha/blob/master/CHANGELOG.md).

To test it I've built and installed it locally and run through the aliases in `test/deps.edn`. They all produced output along these lines:

```
Looking for these deps.edn files:
["/home/cbowdon/.clojure/deps.edn" "deps.edn"]

Produced these dependencies:
[[org.clojure/clojure "1.9.0"]
 [org.clojure/tools.cli "0.3.5"]
 [org.clojure/spec.alpha "0.1.143"]
 [org.clojure/core.specs.alpha "0.1.24"]]

Adding these :resource-paths src
Adding /home/cbowdon/.m2/repository/org/clojure/clojure/1.9.0/clojure-1.9.0.jar to classpath
Adding /home/cbowdon/.m2/repository/org/clojure/tools.cli/0.3.5/tools.cli-0.3.5.jar to classpath
Adding /home/cbowdon/.m2/repository/org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar to classpath
Adding /home/cbowdon/.m2/repository/org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.jar to classpath
``` 

I tweaked the local test to point to a local tools-deps project. I've also tried a project with private repositories with this build and it successfully authenticated and downloaded the artifacts.